### PR TITLE
Tighten validation around `claimToDate`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "^7.4 || ^8.0",
         "ext-dom": "*",
         "ext-xmlwriter": "*",
-        "thebiggive/php-govtalk": "^1.0.0-beta1"
+        "thebiggive/php-govtalk": "^1.0.0-beta2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.7",

--- a/src/GiftAid.php
+++ b/src/GiftAid.php
@@ -587,21 +587,26 @@ class GiftAid extends GovTalk
      * Submit a GA Claim - this is the crux of the biscuit.
      *
      * @param array $donor_data
+     * @return array|bool   Processed response array, or false if initial validation failed.
      */
     public function giftAidSubmit($donor_data)
     {
-        $cChardId      = $this->getClaimingOrganisation()->getHmrcRef();
-        $cOrganisation = 'IR';
-
         $dReturnPeriod = $this->getClaimToDate();
-
-        $sDefaultCurrency = 'GBP'; // currently HMRC only allows GBP
-        $sIRmark          = 'IRmark+Token';
-        $sSender          = 'Individual';
-
-        if ($this->getAuthorisedOfficial() == null) {
+        if (empty($dReturnPeriod)) {
+            $this->logger->error('Cannot proceed without claimToDate');
             return false;
         }
+
+        if ($this->getAuthorisedOfficial() === null) {
+            $this->logger->error('Cannot proceed without authorisedOfficial');
+            return false;
+        }
+
+        $cChardId           = $this->getClaimingOrganisation()->getHmrcRef();
+        $cOrganisation      = 'IR';
+        $sDefaultCurrency   = 'GBP'; // currently HMRC only allows GBP
+        $sIRmark            = 'IRmark+Token';
+        $sSender            = 'Individual';
 
         // Set the message envelope
         $this->setMessageClass('HMRC-CHAR-CLM');

--- a/tests/GovTalk/GiftAid/GiftAidTest.php
+++ b/tests/GovTalk/GiftAid/GiftAidTest.php
@@ -292,6 +292,7 @@ class GiftAidTest extends TestCase
 
         $this->gaService->setAuthorisedOfficial($this->officer);
         $this->gaService->setClaimingOrganisation($this->claimant);
+        $this->gaService->setClaimToDate('2000-01-01');
         $response = $this->gaService->giftAidSubmit($this->claim);
 
         $this->assertArrayHasKey('errors', $response);
@@ -310,6 +311,7 @@ class GiftAidTest extends TestCase
 
         $this->gaService->setAuthorisedOfficial($this->officer);
         $this->gaService->setClaimingOrganisation($this->claimant);
+        $this->gaService->setClaimToDate('2000-01-01');
         $response = $this->gaService->giftAidSubmit($this->claim);
 
         $this->assertArrayNotHasKey('errors', $response);


### PR DESCRIPTION
Fail earlier, with a better message, if this required field is not set