### PR TITLE
Fix tracking current claiming organisation looping over donations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "thebiggive/hmrc-gift-aid",
+    "name": "lee-van-oetz/hmrc-gift-aid",
     "type": "library",
     "description": "A library for charities and CASCs to claim Gift Aid (including Small Donations) from HMRC",
     "homepage": "https://github.com/thebiggive/hmrc-gift-aid",

--- a/src/GiftAid.php
+++ b/src/GiftAid.php
@@ -572,6 +572,7 @@ class GiftAid extends GovTalk
                 $claimOpen = true;
                 $claimNumber++;
                 $gadNumber = 0;
+                $currentClaimOrgRef = $d['org_hmrc_ref'];
             }
 
             if (isset($d['donation_date'])) {


### PR DESCRIPTION
`$currentClaimOrgRef` is never set -- this causes multiple donations being split into multiple claims which in turns causes err 7024  HMRC side of things.